### PR TITLE
:bug:Modify the error in the bpr loss function

### DIFF
--- a/GDE.py
+++ b/GDE.py
@@ -122,7 +122,7 @@ class GDE(nn.Module):
 			out=((final_user*final_pos).sum(1)-nega_weight*res_nega).sigmoid()
 
 		else:	
-			out=((final_user*final_pos).sum(1)-(final_pos*final_nega).sum(1)).sigmoid()
+			out=((final_user*final_pos).sum(1)-(final_user*final_nega).sum(1)).sigmoid()
 
 		reg_term=self.reg*(final_user**2+final_pos**2+final_nega**2).sum()
 		return (-torch.log(out).sum()+reg_term)/batch_size


### PR DESCRIPTION
According to the definition of bpr loss function, [here](https://github.com/tanatosuu/GDE/blob/main/GDE.py#L125) should be modified as:
`out=((final_user*final_pos).sum(1)-(final_user*final_nega).sum(1)).sigmoid()`,
otherwise, loss will be nan when using the bpr loss function